### PR TITLE
Update and rename libxml2-2.14.1.patch to libxml2-2.12.10.patch

### DIFF
--- a/patches/libxml2-2.12.10.patch
+++ b/patches/libxml2-2.12.10.patch
@@ -1,11 +1,11 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -41,7 +41,7 @@
- AC_SUBST(LIBXML_VERSION_NUMBER)
- AC_SUBST(LIBXML_VERSION_EXTRA)
+@@ -40,7 +40,7 @@
  
--AM_INIT_AUTOMAKE([1.16.3 foreign subdir-objects no-dist-gzip dist-xz])
-+AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects no-dist-gzip dist-xz])
+ VERSION=${LIBXML_VERSION}
+ 
+-AM_INIT_AUTOMAKE([1.16.3 foreign no-dist-gzip dist-xz])
++AM_INIT_AUTOMAKE([1.15.1 foreign no-dist-gzip dist-xz])
  AM_MAINTAINER_MODE([enable])
  AM_SILENT_RULES([yes])
  
@@ -25,7 +25,7 @@
  endif
  
 -DIST_SUBDIRS = include . doc example fuzz python xstc
-+DIST_SUBDIRS = include .
++DIST_SUBDIRS = include . python
  
  AM_CPPFLAGS = -I$(top_builddir)/include -I$(srcdir)/include -DSYSCONFDIR='"$(sysconfdir)"'
  


### PR DESCRIPTION
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@
 AC_SUBST(LIBXML_VERSION_NUMBER)
 AC_SUBST(LIBXML_VERSION_EXTRA)
@@ -40,7 +40,7 @@

-AM_INIT_AUTOMAKE([1.16.3 foreign subdir-objects no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([1.15.1 foreign subdir-objects no-dist-gzip dist-xz])
 VERSION=${LIBXML_VERSION}

-AM_INIT_AUTOMAKE([1.16.3 foreign no-dist-gzip dist-xz])
+AM_INIT_AUTOMAKE([1.15.1 foreign no-dist-gzip dist-xz])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])

@@ -25,7 +25,7 @@
 endif

-DIST_SUBDIRS = include . doc example fuzz python xstc
+DIST_SUBDIRS = include .
+DIST_SUBDIRS = include . python

 AM_CPPFLAGS = -I$(top_builddir)/include -I$(srcdir)/include -DSYSCONFDIR='"$(sysconfdir)"'